### PR TITLE
Analyzer should be a development dependency

### DIFF
--- a/ConfigureAwaitChecker.Analyzer/ConfigureAwaitChecker.Analyzer.nuspec
+++ b/ConfigureAwaitChecker.Analyzer/ConfigureAwaitChecker.Analyzer.nuspec
@@ -14,6 +14,7 @@ Checks for `ConfigureAwait(false)` usage.
 More info: http://blog.cincura.net/id/233523/ and http://blog.cincura.net/id/233476/ .
 		</description>
 		<tags>ConfigureAwaitChecker, analyzers, async, await, configureawait</tags>
+		<developmentDependency>true</developmentDependency>
 		<frameworkAssemblies>
 			<frameworkAssembly assemblyName="System" targetFramework="" />
 		</frameworkAssemblies>


### PR DESCRIPTION
Forces the package to be added as development dependency like this

```
  <package id="ConfigureAwaitChecker.Analyzer" version="1.0.0-beta3" targetFramework="net452" developmentDependency="true"/>
```
