### PR TITLE
Remove the obligation to use "false" as a parameter

### DIFF
--- a/ConfigureAwaitChecker.Analyzer.Vsix/source.extension.vsixmanifest
+++ b/ConfigureAwaitChecker.Analyzer.Vsix/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
 	<Metadata>
 		<Identity Id="ConfigureAwaitChecker" Version="1.0" Language="en-US" Publisher="Jiri"/>
 		<DisplayName>ConfigureAwaitChecker.Analyzer</DisplayName>
-		<Description xml:space="preserve">Checks for `ConfigureAwait(false)` usage.
+		<Description xml:space="preserve">Checks for `ConfigureAwait(true|false)` usage.
 
 More info: http://blog.cincura.net/id/233476/ .</Description>
 		<Tags>ConfigureAwaitChecker.Analyzer, analyzers, async, await</Tags>

--- a/ConfigureAwaitChecker.Analyzer/Checker.cs
+++ b/ConfigureAwaitChecker.Analyzer/Checker.cs
@@ -8,73 +8,64 @@ using System.Text;
 
 namespace ConfigureAwaitChecker.Analyzer
 {
-	public sealed class Checker
-	{
-		public static readonly string ConfigureAwaitIdentifier = "ConfigureAwait";
+    public sealed class Checker
+    {
+        public static readonly string ConfigureAwaitIdentifier = "ConfigureAwait";
 
-		static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(
-				languageVersion: LanguageVersion.CSharp6,
-				documentationMode: DocumentationMode.None,
-				kind: SourceCodeKind.Regular);
+        static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(
+                languageVersion: LanguageVersion.CSharp6,
+                documentationMode: DocumentationMode.None,
+                kind: SourceCodeKind.Regular);
 
-		SyntaxTree _tree;
+        SyntaxTree _tree;
 
-		public Checker(Stream file)
-		{
-			using (var reader = new StreamReader(file, Encoding.UTF8, true, 16 * 1024, true))
-			{
-				_tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(),
-					options: ParseOptions);
-			}
-		}
+        public Checker(Stream file)
+        {
+            using (var reader = new StreamReader(file, Encoding.UTF8, true, 16 * 1024, true))
+            {
+                _tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(),
+                    options: ParseOptions);
+            }
+        }
 
-		public IEnumerable<CheckerResult> Check()
-		{
-			foreach (var item in _tree.GetRoot().DescendantNodesAndTokens())
-			{
-				if (item.IsKind(SyntaxKind.AwaitExpression))
-				{
-					var awaitNode = (AwaitExpressionSyntax)item.AsNode();
-					yield return CheckNode(awaitNode);
-				}
-			}
-		}
+        public IEnumerable<CheckerResult> Check()
+        {
+            foreach (var item in _tree.GetRoot().DescendantNodesAndTokens())
+            {
+                if (item.IsKind(SyntaxKind.AwaitExpression))
+                {
+                    var awaitNode = (AwaitExpressionSyntax)item.AsNode();
+                    yield return CheckNode(awaitNode);
+                }
+            }
+        }
 
-		public static CheckerResult CheckNode(AwaitExpressionSyntax awaitNode)
-		{
-			var possibleConfigureAwait = FindExpressionForConfigureAwait(awaitNode);
-			var good = possibleConfigureAwait != null && IsConfigureAwait(possibleConfigureAwait.Expression) && HasFalseArgument(possibleConfigureAwait.ArgumentList);
-			return new CheckerResult(good, awaitNode.GetLocation());
-		}
+        public static CheckerResult CheckNode(AwaitExpressionSyntax awaitNode)
+        {
+            var possibleConfigureAwait = FindExpressionForConfigureAwait(awaitNode);
+            var good = possibleConfigureAwait != null && IsConfigureAwait(possibleConfigureAwait.Expression);
+            return new CheckerResult(good, awaitNode.GetLocation());
+        }
 
-		public static InvocationExpressionSyntax FindExpressionForConfigureAwait(SyntaxNode node)
-		{
-			foreach (var item in node.ChildNodes())
-			{
-				if (item is InvocationExpressionSyntax)
-					return (InvocationExpressionSyntax)item;
-				return FindExpressionForConfigureAwait(item);
-			}
-			return null;
-		}
+        public static InvocationExpressionSyntax FindExpressionForConfigureAwait(SyntaxNode node)
+        {
+            foreach (var item in node.ChildNodes())
+            {
+                if (item is InvocationExpressionSyntax)
+                    return (InvocationExpressionSyntax)item;
+                return FindExpressionForConfigureAwait(item);
+            }
+            return null;
+        }
 
-		public static bool IsConfigureAwait(ExpressionSyntax expression)
-		{
-			var memberAccess = expression as MemberAccessExpressionSyntax;
-			if (memberAccess == null)
-				return false;
-			if (!memberAccess.Name.Identifier.Text.Equals(ConfigureAwaitIdentifier, StringComparison.Ordinal))
-				return false;
-			return true;
-		}
-
-		public static bool HasFalseArgument(ArgumentListSyntax argumentList)
-		{
-			if (argumentList.Arguments.Count != 1)
-				return false;
-			if (!argumentList.Arguments[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression))
-				return false;
-			return true;
-		}
-	}
+        public static bool IsConfigureAwait(ExpressionSyntax expression)
+        {
+            var memberAccess = expression as MemberAccessExpressionSyntax;
+            if (memberAccess == null)
+                return false;
+            if (!memberAccess.Name.Identifier.Text.Equals(ConfigureAwaitIdentifier, StringComparison.Ordinal))
+                return false;
+            return true;
+        }
+    }
 }

--- a/ConfigureAwaitChecker.Analyzer/CheckerResult.cs
+++ b/ConfigureAwaitChecker.Analyzer/CheckerResult.cs
@@ -2,15 +2,15 @@
 
 namespace ConfigureAwaitChecker.Analyzer
 {
-	public sealed class CheckerResult
+    public sealed class CheckerResult
     {
-        public bool HasConfigureAwaitFalse { get; }
+        public bool HasConfigureAwaitExpression { get; }
         public Location Location { get; }
 
-        public CheckerResult(bool hasConfigureAwaitFalse, Location location)
+        public CheckerResult(bool hasConfigureAwaitExpression, Location location)
         {
-            HasConfigureAwaitFalse = hasConfigureAwaitFalse;
-			Location = location;
+            HasConfigureAwaitExpression = hasConfigureAwaitExpression;
+            Location = location;
         }
     }
 }

--- a/ConfigureAwaitChecker.Analyzer/CodeFixProvider.cs
+++ b/ConfigureAwaitChecker.Analyzer/CodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace ConfigureAwaitChecker.Analyzer
 			if (node != null)
 			{
 				context.RegisterCodeFix(
-					   CodeAction.Create("Correct to `ConfigureAwait(false)`", c => Fix(context.Document, node, c)),
+					   CodeAction.Create("Correct to `ConfigureAwait(true|false)`", c => Fix(context.Document, node, c)),
 					   diagnostic);
 			}
 		}
@@ -50,13 +50,6 @@ namespace ConfigureAwaitChecker.Analyzer
 					var falseExpression = SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression);
 					var newExpression = SyntaxFactory.InvocationExpression(
 						SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, SyntaxFactory.IdentifierName(Checker.ConfigureAwaitIdentifier)),
-						SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[] { SyntaxFactory.Argument(falseExpression) })));
-					return document.WithSyntaxRoot(root.ReplaceNode(expression, newExpression.WithAdditionalAnnotations(Formatter.Annotation)));
-				}
-				if (!Checker.HasFalseArgument(expression.ArgumentList))
-				{
-					var falseExpression = SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression);
-					var newExpression = SyntaxFactory.InvocationExpression(expression.Expression,
 						SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[] { SyntaxFactory.Argument(falseExpression) })));
 					return document.WithSyntaxRoot(root.ReplaceNode(expression, newExpression.WithAdditionalAnnotations(Formatter.Annotation)));
 				}

--- a/ConfigureAwaitChecker.Analyzer/ConfigureAwaitChecker.Analyzer.nuspec
+++ b/ConfigureAwaitChecker.Analyzer/ConfigureAwaitChecker.Analyzer.nuspec
@@ -9,7 +9,7 @@
 		<projectUrl>https://github.com/cincuranet/ConfigureAwaitChecker</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>
-Checks for `ConfigureAwait(false)` usage.
+Checks for `ConfigureAwait(true|false)` usage.
 
 More info: http://blog.cincura.net/id/233523/ and http://blog.cincura.net/id/233476/ .
 		</description>

--- a/ConfigureAwaitChecker.Analyzer/DiagnosticAnalyzer.cs
+++ b/ConfigureAwaitChecker.Analyzer/DiagnosticAnalyzer.cs
@@ -6,33 +6,33 @@ using System.Collections.Immutable;
 
 namespace ConfigureAwaitChecker.Analyzer
 {
-	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-	public sealed class ConfigureAwaitCheckerAnalyzer : DiagnosticAnalyzer
-	{
-		public const string DiagnosticId = "ConfigureAwaitChecker";
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ConfigureAwaitCheckerAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "ConfigureAwaitChecker";
 
-		static readonly string Title = "CAC001";
-		static readonly string MessageFormat = "Possibly missing `ConfigureAwait(false)` call";
-		const string Category = "Code";
+        static readonly string Title = "CAC001";
+        static readonly string MessageFormat = "Possibly missing `ConfigureAwait(true|false)` call";
+        const string Category = "Code";
 
-		static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+        static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-		public override void Initialize(AnalysisContext context)
-		{
-			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.AwaitExpression);
-		}
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.AwaitExpression);
+        }
 
-		static void Analyze(SyntaxNodeAnalysisContext context)
-		{
-			var awaitNode = (AwaitExpressionSyntax)context.Node;
-			var check = Checker.CheckNode(awaitNode);
-            if (!check.HasConfigureAwaitFalse)
-			{
-				var diagnostic = Diagnostic.Create(Rule, check.Location);
-				context.ReportDiagnostic(diagnostic);
-			}
-		}
-	}
+        static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var awaitNode = (AwaitExpressionSyntax)context.Node;
+            var check = Checker.CheckNode(awaitNode);
+            if (!check.HasConfigureAwaitExpression)
+            {
+                var diagnostic = Diagnostic.Create(Rule, check.Location);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
 }

--- a/ConfigureAwaitChecker.Console/ConfigureAwaitChecker.Console.csproj
+++ b/ConfigureAwaitChecker.Console/ConfigureAwaitChecker.Console.csproj
@@ -13,6 +13,21 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -70,6 +85,18 @@
       <Project>{2294167d-0011-4260-a815-e5cb1e8faa7a}</Project>
       <Name>ConfigureAwaitChecker.Analyzer</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.5">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.5 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ConfigureAwaitChecker.Console/Program.cs
+++ b/ConfigureAwaitChecker.Console/Program.cs
@@ -20,14 +20,14 @@ namespace ConfigureAwaitChecker.Console
 			foreach (var item in CreateChecker(args[0]).Check())
 			{
 				var location = item.Location.GetMappedLineSpan().StartLinePosition;
-				if (!item.HasConfigureAwaitFalse)
+				if (!item.HasConfigureAwaitExpression)
 				{
-					ConsoleWriteLine($"ERROR: Missing `ConfigureAwait(false)` for await on line {location.Line} column {location.Character}.", ConsoleColor.Red);
+					ConsoleWriteLine($"ERROR: Missing `ConfigureAwait(true|false)` for await on line {location.Line} column {location.Character}.", ConsoleColor.Red);
 					result = ExitCodes.Error;
 				}
 				else
 				{
-					ConsoleWriteLine($"GOOD: Found `ConfigureAwait(false)` for await on line {location.Line} column {location.Character}.", ConsoleColor.Green);
+					ConsoleWriteLine($"GOOD: Found `ConfigureAwait(true|false)` for await on line {location.Line} column {location.Character}.", ConsoleColor.Green);
 				}
 			}
 

--- a/ConfigureAwaitChecker.Tests/CheckerTests.cs
+++ b/ConfigureAwaitChecker.Tests/CheckerTests.cs
@@ -28,7 +28,7 @@ namespace ConfigureAwaitChecker.Tests
 			foreach (var item in results)
 			{
 				var location = item.Location.GetMappedLineSpan().StartLinePosition;
-				sb.Append($"Result:{item.HasConfigureAwaitFalse}\tL:{location.Line,-6}|C:{location.Character}");
+				sb.Append($"Result:{item.HasConfigureAwaitExpression}\tL:{location.Line,-6}|C:{location.Character}");
 				sb.AppendLine();
 			}
 			return sb.ToString();
@@ -36,7 +36,7 @@ namespace ConfigureAwaitChecker.Tests
 
 		[TestCase(typeof(SimpleAwait_Missing), ExpectedResult = new[] { false })]
 		[TestCase(typeof(SimpleAwait_Fine), ExpectedResult = new[] { true })]
-		[TestCase(typeof(SimpleAwait_WithTrue), ExpectedResult = new[] { false })]
+		[TestCase(typeof(SimpleAwait_WithTrue), ExpectedResult = new[] { true })]
 		[TestCase(typeof(SimpleAwaitWithBraces_Missing), ExpectedResult = new[] { false })]
 		[TestCase(typeof(SimpleAwaitWithBracesAll_Fine), ExpectedResult = new[] { true })]
 		[TestCase(typeof(SimpleAwaitWithBracesTask_Fine), ExpectedResult = new[] { true })]
@@ -67,7 +67,7 @@ namespace ConfigureAwaitChecker.Tests
 			var checker = CreateChecker(testClass);
 			var result = checker.Check().ToArray();
 			Console.WriteLine(Dump(result));
-			return result.Select(x => x.HasConfigureAwaitFalse).ToArray();
+			return result.Select(x => x.HasConfigureAwaitExpression).ToArray();
 		}
 	}
 }

--- a/ConfigureAwaitChecker.Tests/ConfigureAwaitChecker.Tests.csproj
+++ b/ConfigureAwaitChecker.Tests/ConfigureAwaitChecker.Tests.csproj
@@ -53,7 +53,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CheckerTests.cs" />
-    <Compile Include="Scratchpad.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestClasses\ThrowAwait_Fine.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/ConfigureAwaitChecker.Tests/Scratchpad.cs
+++ b/ConfigureAwaitChecker.Tests/Scratchpad.cs
@@ -1,9 +1,0 @@
-﻿using NUnit.Framework;
-
-namespace ConfigureAwaitChecker.Tests
-{
-	[TestFixture]
-    public class Scratchpad
-    {
-    }
-}


### PR DESCRIPTION
Hello,

Are you still maintaining this code ?

I wanted to use the nuget package in one of my project but found that forcing the use of the "false" argument was a bit too strict for some scenarios.
I just modified the code to remove the validation of the "false" argument.

I think it's a good practice to specify ConfigureAwait every time we use an "await" instruction.
The developper must ask himself if he needs to capture the SynchronisationContext or not.
But if he choose that he needs to for some particular reason, the rule should allow it.

Thanks