### PR TITLE
Add a second rule "CAC002" to handle existing `ConfigureAwait(true)`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+; Visual Studio Extension : http://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328
+; See http://editorconfig.org/ for more informations
+; Top-most EditorConfig file
+root = true
+
+[*.cs]
+end_of_line = CRLF
+indent_style = tab

--- a/ConfigureAwaitChecker.Analyzer/CodeFixProvider.cs
+++ b/ConfigureAwaitChecker.Analyzer/CodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace ConfigureAwaitChecker.Analyzer
 	{
 		public override ImmutableArray<string> FixableDiagnosticIds
 		{
-			get { return ImmutableArray.Create(ConfigureAwaitCheckerAnalyzer.DiagnosticId); }
+			get { return ImmutableArray.Create(ConfigureAwaitCheckerAnalyzer.AddConfigureAwaitFalseDiagnosticId, ConfigureAwaitCheckerAnalyzer.SwitchToConfigureAwaitFalseDiagnosticId); }
 		}
 
 		public override FixAllProvider GetFixAllProvider()

--- a/ConfigureAwaitChecker.Lib/Checker.cs
+++ b/ConfigureAwaitChecker.Lib/Checker.cs
@@ -46,19 +46,11 @@ namespace ConfigureAwaitChecker.Lib
 			var possibleConfigureAwait = FindExpressionForConfigureAwait(awaitNode);
 			if (possibleConfigureAwait != null && IsConfigureAwait(possibleConfigureAwait.Expression))
 			{
-				if (HasFalseArgument(possibleConfigureAwait.ArgumentList))
-				{
-					return new CheckerResult(false, awaitNode.GetLocation());
-				}
-				else
-				{
-					return new CheckerResult(true, awaitNode.GetLocation());
-				}
+				return new CheckerResult(awaitNode.GetLocation()) { NeedsSwitchConfigureAwaitToFalse = !HasFalseArgument(possibleConfigureAwait.ArgumentList) };
 			}
 			else
 			{
-				var can = CanHaveConfigureAwait(awaitNode.Expression, semanticModel);
-				return new CheckerResult(can, awaitNode.GetLocation());
+				return new CheckerResult(awaitNode.GetLocation()) { NeedsAddConfigureAwaitFalse = CanHaveConfigureAwait(awaitNode.Expression, semanticModel) };
 			}
 		}
 

--- a/ConfigureAwaitChecker.Lib/CheckerResult.cs
+++ b/ConfigureAwaitChecker.Lib/CheckerResult.cs
@@ -4,12 +4,12 @@ namespace ConfigureAwaitChecker.Lib
 {
 	public sealed class CheckerResult
 	{
-		public bool NeedsConfigureAwaitFalse { get; }
-		public Location Location { get; }
+		public bool NeedsAddConfigureAwaitFalse { get; internal set; }
+		public bool NeedsSwitchConfigureAwaitToFalse { get; internal set; }
+		public Location Location { get; internal set; }
 
-		public CheckerResult(bool needsConfigureAwaitFalse, Location location)
+		public CheckerResult(Location location)
 		{
-			NeedsConfigureAwaitFalse = needsConfigureAwaitFalse;
 			Location = location;
 		}
 	}

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitInIf_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitInIf_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class AwaitInIf_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitInIf_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitInIf_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class AwaitInIf_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitInUsing_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitInUsing_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class AwaitInUsing_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitInUsing_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitInUsing_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class AwaitInUsing_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitOnAwaiter_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitOnAwaiter_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class AwaitOnAwaiter_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitOnAwaiter_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitOnAwaiter_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class AwaitOnAwaiter_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/AwaitTaskYield_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/AwaitTaskYield_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class AwaitTaskYield_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/CallOnResult_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/CallOnResult_Fine.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class CallOnResult_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/CallOnResult_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/CallOnResult_Missing.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class CallOnResult_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_Fine.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false, false })]
+[CheckerTests.ExpectedResult(new[] { false, false }, new[] { false, false })]
 public class ExecutingAsyncLambda_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_MissingAll.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_MissingAll.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true, true })]
+[CheckerTests.ExpectedResult(new[] { true, true }, new[] { false, false })]
 public class ExecutingAsyncLambda_MissingAll : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_MissingInner.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_MissingInner.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false, true })]
+[CheckerTests.ExpectedResult(new[] { false, true }, new[] { false, false })]
 public class ExecutingAsyncLambda_MissingInner : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_MissingOuter.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ExecutingAsyncLambda_MissingOuter.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true, false })]
+[CheckerTests.ExpectedResult(new[] { true, false }, new[] { false, false })]
 public class ExecutingAsyncLambda_MissingOuter : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false, false })]
+[CheckerTests.ExpectedResult(new[] { false, false }, new[] { false, false })]
 public class NestedFunctionCalls_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_MissingAll.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_MissingAll.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true, true })]
+[CheckerTests.ExpectedResult(new[] { true, true }, new[] { false, false })]
 public class NestedFunctionCalls_MissingAll : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_MissingInner.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_MissingInner.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false, true })]
+[CheckerTests.ExpectedResult(new[] { false, true }, new[] { false, false })]
 public class NestedFunctionCalls_MissingInner : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_MissingOuter.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/NestedFunctionCalls_MissingOuter.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true, false })]
+[CheckerTests.ExpectedResult(new[] { true, false }, new[] { false, false })]
 public class NestedFunctionCalls_MissingOuter : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwaitWithBracesAll_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwaitWithBracesAll_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class SimpleAwaitWithBracesAll_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwaitWithBracesTask_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwaitWithBracesTask_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class SimpleAwaitWithBracesTask_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwaitWithBraces_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwaitWithBraces_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class SimpleAwaitWithBraces_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwait_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwait_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class SimpleAwait_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwait_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwait_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class SimpleAwait_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwait_WithTrue.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleAwait_WithTrue.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { true })]
 public class SimpleAwait_WithTrue : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambdaWithBraces_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambdaWithBraces_Fine.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class SimpleLambdaWithBraces_Fine : TestClassBase
 {
 #pragma warning disable 1998

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambdaWithBraces_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambdaWithBraces_Missing.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class SimpleLambdaWithBraces_Missing : TestClassBase
 {
 #pragma warning disable 1998

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambda_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambda_Fine.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class SimpleLambda_Fine : TestClassBase
 {
 #pragma warning disable 1998

--- a/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambda_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/SimpleLambda_Missing.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class SimpleLambda_Missing : TestClassBase
 {
 #pragma warning disable 1998

--- a/ConfigureAwaitChecker.Tests/TestClasses/ThrowAwait_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ThrowAwait_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class ThrowAwait_Fine : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ThrowAwait_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ThrowAwait_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class ThrowAwait_Missing : TestClassBase
 {
 	public async Task FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ValueTaskSimpleAwait_Fine.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ValueTaskSimpleAwait_Fine.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { false })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { false })]
 public class ValueTaskSimpleAwait_Fine : TestClassBase
 {
 	public async ValueTask FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ValueTaskSimpleAwait_Missing.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ValueTaskSimpleAwait_Missing.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { true }, new[] { false })]
 public class ValueTaskSimpleAwait_Missing : TestClassBase
 {
 	public async ValueTask FooBar()

--- a/ConfigureAwaitChecker.Tests/TestClasses/ValueTaskSimpleAwait_WithTrue.cs
+++ b/ConfigureAwaitChecker.Tests/TestClasses/ValueTaskSimpleAwait_WithTrue.cs
@@ -2,7 +2,7 @@
 using ConfigureAwaitChecker.Tests;
 using ConfigureAwaitChecker.Tests.TestClasses;
 
-[CheckerTests.ExpectedResult(new[] { true })]
+[CheckerTests.ExpectedResult(new[] { false }, new[] { true })]
 public class ValueTaskSimpleAwait_WithTrue : TestClassBase
 {
 	public async ValueTask FooBar()

--- a/ConfigureAwaitChecker.sln
+++ b/ConfigureAwaitChecker.sln
@@ -11,6 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfigureAwaitChecker.Lib",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7AA16325-0A47-4E5F-BDEB-5B798A5A584E}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject


### PR DESCRIPTION
that way, that permits to ignore globally this rule in project where that make sense.
Also add the advantage to have a different warning label.

+ fix Diagnostic `Id` that was inverted with `title` in `DiagnosticDescriptor()` constructor call

What I really want to avoid (all normal `.ConfigureAwait(true)` calls  😢 :

![image](https://user-images.githubusercontent.com/460196/48347904-f4607f80-e67f-11e8-9248-98f805848e62.png)


What it looks like with this PR:

![image](https://user-images.githubusercontent.com/460196/48347188-d3972a80-e67d-11e8-92ba-4f7f1bb17d6b.png)
