### PR TITLE
Add license to nuget packages

### DIFF
--- a/ConfigureAwaitChecker.Analyzer/ConfigureAwaitChecker.Analyzer.csproj
+++ b/ConfigureAwaitChecker.Analyzer/ConfigureAwaitChecker.Analyzer.csproj
@@ -10,6 +10,7 @@
 		<PackageVersion>$(Version)</PackageVersion>
 		<Authors>Jiří Činčura</Authors>
 		<PackageProjectUrl>https://github.com/cincuranet/ConfigureAwaitChecker</PackageProjectUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>Checks for `ConfigureAwait(false)` usage.
 

--- a/ConfigureAwaitChecker.Lib/ConfigureAwaitChecker.Lib.csproj
+++ b/ConfigureAwaitChecker.Lib/ConfigureAwaitChecker.Lib.csproj
@@ -9,6 +9,7 @@
 		<PackageVersion>$(Version)</PackageVersion>
 		<Authors>Jiří Činčura</Authors>
 		<PackageProjectUrl>https://github.com/cincuranet/ConfigureAwaitChecker</PackageProjectUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>Library to check for `ConfigureAwait(false)` usage.
 


### PR DESCRIPTION
This PR adds the license to the generated nuget packages, such that it will be showed in the nuget.org UI and when using `Get-Package` to show license information.